### PR TITLE
removing vestigal sra parameter from spec files, yaml files etc

### DIFF
--- a/genome_transform.spec
+++ b/genome_transform.spec
@@ -160,7 +160,6 @@ module genome_transform {
         list <string> file_path_list;
         workspace_id workspace;
         object_id reads_id;
-        string sra;
         string outward;
         float insert_size;
         float std_dev;
@@ -174,7 +173,6 @@ module genome_transform {
         list <string> file_path_list;
         workspace_id workspace;
         object_id reads_id;
-        string sra;
         string outward;
         float insert_size;
         float std_dev;

--- a/lib/genome_transform/genome_transformClient.pm
+++ b/lib/genome_transform/genome_transformClient.pm
@@ -524,7 +524,7 @@ object_id is a string
 
 =head2 sra_reads_to_assembly
 
-  $return = $obj->sra_reads_to_assembly($reads_to_assembly_params)
+  $return = $obj->sra_reads_to_assembly($sra_reads_to_assembly_params)
 
 =over 4
 
@@ -533,9 +533,9 @@ object_id is a string
 =begin html
 
 <pre>
-$reads_to_assembly_params is a genome_transform.reads_to_assembly_params
+$sra_reads_to_assembly_params is a genome_transform.sra_reads_to_assembly_params
 $return is a genome_transform.object_id
-reads_to_assembly_params is a reference to a hash where the following keys are defined:
+sra_reads_to_assembly_params is a reference to a hash where the following keys are defined:
 	reads_shock_ref has a value which is a genome_transform.shock_ref
 	reads_handle_ref has a value which is a genome_transform.handle_ref
 	reads_type has a value which is a string
@@ -556,9 +556,9 @@ object_id is a string
 
 =begin text
 
-$reads_to_assembly_params is a genome_transform.reads_to_assembly_params
+$sra_reads_to_assembly_params is a genome_transform.sra_reads_to_assembly_params
 $return is a genome_transform.object_id
-reads_to_assembly_params is a reference to a hash where the following keys are defined:
+sra_reads_to_assembly_params is a reference to a hash where the following keys are defined:
 	reads_shock_ref has a value which is a genome_transform.shock_ref
 	reads_handle_ref has a value which is a genome_transform.handle_ref
 	reads_type has a value which is a string
@@ -596,10 +596,10 @@ object_id is a string
 							       "Invalid argument count for function sra_reads_to_assembly (received $n, expecting 1)");
     }
     {
-	my($reads_to_assembly_params) = @args;
+	my($sra_reads_to_assembly_params) = @args;
 
 	my @_bad_arguments;
-        (ref($reads_to_assembly_params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"reads_to_assembly_params\" (value was \"$reads_to_assembly_params\")");
+        (ref($sra_reads_to_assembly_params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"sra_reads_to_assembly_params\" (value was \"$sra_reads_to_assembly_params\")");
         if (@_bad_arguments) {
 	    my $msg = "Invalid arguments passed to sra_reads_to_assembly:\n" . join("", map { "\t$_\n" } @_bad_arguments);
 	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
@@ -1091,6 +1091,37 @@ a float
 
 
 
+=head2 sra
+
+=over 4
+
+
+
+=item Description
+
+sequence type
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a string
+</pre>
+
+=end html
+
+=begin text
+
+a string
+
+=end text
+
+=back
+
+
+
 =head2 genbank_to_genome_params
 
 =over 4
@@ -1253,6 +1284,52 @@ file_path file_path - optional path to genbank file on local file system
 workspace_id workspace - workspace where object will be saved
 object_id reads_id - workspace ID to which the genome object should be saved
 object_id contigset_id - workspace ID to which the contigs should be saved
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+reads_shock_ref has a value which is a genome_transform.shock_ref
+reads_handle_ref has a value which is a genome_transform.handle_ref
+reads_type has a value which is a string
+file_path_list has a value which is a reference to a list where each element is a string
+workspace has a value which is a genome_transform.workspace_id
+reads_id has a value which is a genome_transform.object_id
+outward has a value which is a string
+insert_size has a value which is a float
+std_dev has a value which is a float
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+reads_shock_ref has a value which is a genome_transform.shock_ref
+reads_handle_ref has a value which is a genome_transform.handle_ref
+reads_type has a value which is a string
+file_path_list has a value which is a reference to a list where each element is a string
+workspace has a value which is a genome_transform.workspace_id
+reads_id has a value which is a genome_transform.object_id
+outward has a value which is a string
+insert_size has a value which is a float
+std_dev has a value which is a float
+
+
+=end text
+
+=back
+
+
+
+=head2 sra_reads_to_assembly_params
+
+=over 4
+
 
 
 =item Definition

--- a/lib/genome_transform/genome_transformClient.py
+++ b/lib/genome_transform/genome_transformClient.py
@@ -199,10 +199,10 @@ class genome_transform(object):
                           [reads_to_assembly_params], json_rpc_context)
         return resp[0]
   
-    def sra_reads_to_assembly(self, reads_to_assembly_params, json_rpc_context = None):
+    def sra_reads_to_assembly(self, sra_reads_to_assembly_params, json_rpc_context = None):
         if json_rpc_context and type(json_rpc_context) is not dict:
             raise ValueError('Method sra_reads_to_assembly: argument json_rpc_context is not type dict as required.')
         resp = self._call('genome_transform.sra_reads_to_assembly',
-                          [reads_to_assembly_params], json_rpc_context)
+                          [sra_reads_to_assembly_params], json_rpc_context)
         return resp[0]
  

--- a/lib/genome_transform/genome_transformImpl.pm
+++ b/lib/genome_transform/genome_transformImpl.pm
@@ -1,9 +1,8 @@
 package genome_transform::genome_transformImpl;
 use strict;
 use Bio::KBase::Exceptions;
-
 # Use Semantic Versioning (2.0.0-rc.1)
-# http://semver.org
+# http://semver.org 
 our $VERSION = "0.1.0";
 
 =head1 NAME
@@ -758,7 +757,6 @@ reads_to_assembly_params is a reference to a hash where the following keys are d
 	file_path_list has a value which is a reference to a list where each element is a string
 	workspace has a value which is a genome_transform.workspace_id
 	reads_id has a value which is a genome_transform.object_id
-	sra has a value which is a string
 	outward has a value which is a string
 	insert_size has a value which is a float
 	std_dev has a value which is a float
@@ -782,7 +780,6 @@ reads_to_assembly_params is a reference to a hash where the following keys are d
 	file_path_list has a value which is a reference to a list where each element is a string
 	workspace has a value which is a genome_transform.workspace_id
 	reads_id has a value which is a genome_transform.object_id
-	sra has a value which is a string
 	outward has a value which is a string
 	insert_size has a value which is a float
 	std_dev has a value which is a float
@@ -952,7 +949,6 @@ sra_reads_to_assembly_params is a reference to a hash where the following keys a
 	file_path_list has a value which is a reference to a list where each element is a string
 	workspace has a value which is a genome_transform.workspace_id
 	reads_id has a value which is a genome_transform.object_id
-	sra has a value which is a string
 	outward has a value which is a string
 	insert_size has a value which is a float
 	std_dev has a value which is a float
@@ -976,7 +972,6 @@ sra_reads_to_assembly_params is a reference to a hash where the following keys a
 	file_path_list has a value which is a reference to a list where each element is a string
 	workspace has a value which is a genome_transform.workspace_id
 	reads_id has a value which is a genome_transform.object_id
-	sra has a value which is a string
 	outward has a value which is a string
 	insert_size has a value which is a float
 	std_dev has a value which is a float
@@ -1124,7 +1119,7 @@ sub sra_reads_to_assembly
 
 
 
-=head2 version
+=head2 version 
 
   $return = $obj->version()
 
@@ -1772,7 +1767,6 @@ reads_type has a value which is a string
 file_path_list has a value which is a reference to a list where each element is a string
 workspace has a value which is a genome_transform.workspace_id
 reads_id has a value which is a genome_transform.object_id
-sra has a value which is a string
 outward has a value which is a string
 insert_size has a value which is a float
 std_dev has a value which is a float
@@ -1790,7 +1784,6 @@ reads_type has a value which is a string
 file_path_list has a value which is a reference to a list where each element is a string
 workspace has a value which is a genome_transform.workspace_id
 reads_id has a value which is a genome_transform.object_id
-sra has a value which is a string
 outward has a value which is a string
 insert_size has a value which is a float
 std_dev has a value which is a float
@@ -1820,7 +1813,6 @@ reads_type has a value which is a string
 file_path_list has a value which is a reference to a list where each element is a string
 workspace has a value which is a genome_transform.workspace_id
 reads_id has a value which is a genome_transform.object_id
-sra has a value which is a string
 outward has a value which is a string
 insert_size has a value which is a float
 std_dev has a value which is a float
@@ -1838,7 +1830,6 @@ reads_type has a value which is a string
 file_path_list has a value which is a reference to a list where each element is a string
 workspace has a value which is a genome_transform.workspace_id
 reads_id has a value which is a genome_transform.object_id
-sra has a value which is a string
 outward has a value which is a string
 insert_size has a value which is a float
 std_dev has a value which is a float

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -70,9 +70,9 @@ function genome_transform(url, auth, auth_cb, timeout, async_job_check_time_ms, 
             [reads_to_assembly_params], 1, _callback, _errorCallback);
     };
  
-     this.sra_reads_to_assembly = function (reads_to_assembly_params, _callback, _errorCallback) {
-        if (typeof reads_to_assembly_params === 'function')
-            throw 'Argument reads_to_assembly_params can not be a function';
+     this.sra_reads_to_assembly = function (sra_reads_to_assembly_params, _callback, _errorCallback) {
+        if (typeof sra_reads_to_assembly_params === 'function')
+            throw 'Argument sra_reads_to_assembly_params can not be a function';
         if (_callback && typeof _callback !== 'function')
             throw 'Argument _callback must be a function if defined';
         if (_errorCallback && typeof _errorCallback !== 'function')
@@ -80,7 +80,7 @@ function genome_transform(url, auth, auth_cb, timeout, async_job_check_time_ms, 
         if (typeof arguments === 'function' && arguments.length > 1+2)
             throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
         return json_call_ajax("genome_transform.sra_reads_to_assembly",
-            [reads_to_assembly_params], 1, _callback, _errorCallback);
+            [sra_reads_to_assembly_params], 1, _callback, _errorCallback);
     };
   
 

--- a/lib/src/us/kbase/genometransform/GenomeTransformClient.java
+++ b/lib/src/us/kbase/genometransform/GenomeTransformClient.java
@@ -211,12 +211,12 @@ public class GenomeTransformClient {
      * <p>Original spec-file function name: sra_reads_to_assembly</p>
      * <pre>
      * </pre>
-     * @param   arg1   instance of type {@link us.kbase.genometransform.ReadsToAssemblyParams ReadsToAssemblyParams} (original type "reads_to_assembly_params")
+     * @param   arg1   instance of type {@link us.kbase.genometransform.SraReadsToAssemblyParams SraReadsToAssemblyParams} (original type "sra_reads_to_assembly_params")
      * @return   instance of original type "object_id" (Name of an object in the KBase workspace)
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
-    public String sraReadsToAssembly(ReadsToAssemblyParams arg1, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+    public String sraReadsToAssembly(SraReadsToAssemblyParams arg1, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         args.add(arg1);
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};

--- a/ui/narrative/methods/sra_reads_to_assembly/display.yaml
+++ b/ui/narrative/methods/sra_reads_to_assembly/display.yaml
@@ -36,9 +36,6 @@ parameters :
     outward:
         ui-name : flag is set to 1 if reads in the pair point outward
         short-hint : flag is set to 1 if reads in the pair point outward
-    sra:
-        ui-name : flag is set to 1 if reads in the pair point outward
-        short-hint : flag is set to 1 if reads in the pair point outward
     insert_size:
         ui-name : Insert size
         short-hint : Insert size

--- a/ui/narrative/methods/sra_reads_to_assembly/spec.json
+++ b/ui/narrative/methods/sra_reads_to_assembly/spec.json
@@ -38,21 +38,6 @@
           }
         },
         {
-         "field_type" : "checkbox",
-         "allow_multiple" : false,
-         "optional" : false,
-         "id" : "sra",
-         "advanced" : false,
-         "default_values" : [1],
-          "checkbox_options" : {
-            "unchecked_value" : 0,
-            "checked_value" : 1
-          },
-          "text_options" : {
-            "valid_ws_types" : []
-          }
-        },
-        {
             "id" : "reads_id",
             "optional" : false,
             "advanced" : false,
@@ -125,10 +110,6 @@
                 {
                     "input_parameter": "outward",
                     "target_property": "outward"
-                },
-                {
-                    "input_parameter": "sra",
-                    "target_property": "sra"
                 },
                 {
                     "input_parameter": "insert_size",


### PR DESCRIPTION
took out all references to the "sra" parameter from the genome_transform.spec file, ui/narrative/methods/sra_reads_to_assembly/display.yaml and json.spec and re-ran "make" to rerun the KIDL.  
