### PR TITLE
bug fix for uncompressing files which are read-only

### DIFF
--- a/test/compressed_reads_test.pl
+++ b/test/compressed_reads_test.pl
@@ -35,16 +35,16 @@ my @comp_fastas = (
 
 );
 
-print "begin fasta_to_contig test\n";
-
-foreach my $input_parms ( @comp_fastas )
-   {
-    eval {
-          my $ret =$impl->fasta_to_contig( $input_parms );
-        };
-   }
-
-print "end fasta_to_contigtest\n";
+#print "begin fasta_to_contig test\n";
+#
+#foreach my $input_parms ( @comp_fastas )
+#   {
+#    #eval {
+#          my $ret =$impl->fasta_to_contig( $input_parms );
+#    #    };
+#   }
+#
+#print "end fasta_to_contigtest\n";
 
 my @comp_tsv = (
    {
@@ -56,16 +56,16 @@ my @comp_tsv = (
    }
 );
 
-print "begin tsv_to_exp test\n";
-
-foreach my $input_parms ( @comp_tsv )
-   {
-    eval {
-          my $ret = $impl->tsv_to_exp( $input_parms );
-         };
-   }
-
-print "end tsv_to_exp test\n";
+#print "begin tsv_to_exp test\n";
+#
+#foreach my $input_parms ( @comp_tsv )
+#   {
+#    #eval {
+#          my $ret = $impl->tsv_to_exp( $input_parms );
+#    #     };
+#   }
+#
+#print "end tsv_to_exp test\n";
 
 my @comp_gbks = (
    {
@@ -105,9 +105,9 @@ print "begin genbank_to_genome test\n";
 
 foreach my $input_parms ( @comp_gbks )
    {
-    eval {
+    #eval {
           my $ret =$impl->genbank_to_genome( $input_parms );
-        };
+    #    };
    }
 
 print "end genbank_to_genome test\n";
@@ -179,12 +179,12 @@ my @comp_fastqs = (
 print "begin reads_to_assembly test\n";
 foreach my $input_parms ( @comp_fastqs )
    {
-    eval {
+    #eval {
           { my $ret = $impl->reads_to_assembly( $input_parms );
             print "returns\n"; 
             print Dumper( $ret ); 
           }
-         };
+    #     };
    }
 print "end reads_to_assembly test\n";
 

--- a/test/sra_reads_to_assembly_test.pl
+++ b/test/sra_reads_to_assembly_test.pl
@@ -25,11 +25,11 @@ $input_sra = {
 
     reads_shock_ref => 'https://ci.kbase.us/services/shock-api/',
     reads_handle_ref => 'https://ci.kbase.us/services/handle_servce',
-    #reads_type => 'PairedEndLibrary',
-    reads_type => 'SingleEndLibrary',
+    reads_type => 'PairedEndLibrary',
+    #reads_type => 'SingleEndLibrary',
     file_path_list => [ '/kb/module/data/SRR3944606.sra' ],
     workspace => '9196',
-    reads_id => 'ThridSRAreads',
+    reads_id => 'ForthSRAreads',
     # string outward;
     # float insert_size;
     # float std_dev;


### PR DESCRIPTION
modified the handling of gunzip and bunzip2 decompression to ensure any new files are created in the awe job workspace regardless of input file pathnames and whether or not they are write-protected
