### PR TITLE
added handling for getting direct shock url from redirection service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,14 @@ RUN cd /kb/dev_container/modules && \
 # Get perl MMagic library for identifying compressed types
 RUN cpanm File::MMagic
 
+# Get LWP::UserAgent and HTTP::Request needed for handling shock-service redirect
+RUN cpanm HTTP::Request
+RUN cpanm LWP::UserAgent
+
 # Get NCBI SRATools (for fastq-dump)
 RUN cd /kb/dev_container/modules && \
     mkdir NCBI_SRA_tools && cd NCBI_SRA_tools && \
-    curl 'http://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/2.7.0/sratoolkit.2.7.0-ubuntu64.tar.gz' -O && \
+    curl 'https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/2.7.0/sratoolkit.2.7.0-ubuntu64.tar.gz' -O && \
     tar zxf sratoolkit.2.7.0-ubuntu64.tar.gz && \
     cp sratoolkit.2.7.0-ubuntu64/bin/fastq-dump.2.7.0  /kb/deployment/bin/fastq-dump
 


### PR DESCRIPTION
added code to  sub determine_relevant_shock_url for accessing shock-direct url to get the correct url for direct shock uploads as opposed to using the nginx proxy

Uses LWP::UserAgent and HTTP::Request.  Both of these added to Dockerfile and also changed NCBI sratools url to use the new HTTPS at NCBI.
